### PR TITLE
Primitives should not be boxed just for "String" conversion

### DIFF
--- a/oneSheeld/src/main/java/com/integreight/onesheeld/MainActivity.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/MainActivity.java
@@ -324,7 +324,7 @@ public class MainActivity extends FragmentActivity {
                     }
                     getThisApplication().getTracker().send(
                             new HitBuilders.ScreenViewBuilder()
-                                    .setCustomDimension(2, version + "")
+                                    .setCustomDimension(2, String.valueOf(version))
                                     .build());
                 }
             });

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/model/InternetRequest.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/model/InternetRequest.java
@@ -179,7 +179,7 @@ public class InternetRequest {
 
     public InternetResponse getResponse() {
         try {
-            return InternetManager.getInstance().getCachDB().get(id + "", InternetResponse.class);
+            return InternetManager.getInstance().getCachDB().get(String.valueOf(id), InternetResponse.class);
         } catch (SnappydbException e) {
             return null;
         }
@@ -187,7 +187,7 @@ public class InternetRequest {
 
     public void setResponse(InternetResponse response) {
         try {
-            InternetManager.getInstance().getCachDB().put(id + "", response);
+            InternetManager.getInstance().getCachDB().put(String.valueOf(id), response);
         } catch (SnappydbException e) {
             e.printStackTrace();
         }

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/popup/FirmwareUpdatingPopup.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/popup/FirmwareUpdatingPopup.java
@@ -288,7 +288,7 @@ public class FirmwareUpdatingPopup extends Dialog {
                                                   Throwable error) {
                                 changeSlogan("Error Downloading!", COLOR.RED);
                                 setUpgrade();
-                                Log.d("bootloader", statusCode + "");
+                                Log.d("bootloader", String.valueOf(statusCode));
                                 activity.getThisApplication()
                                         .getTracker()
                                         .send(new HitBuilders.EventBuilder()

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/shields/controller/ClockShield.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/shields/controller/ClockShield.java
@@ -41,9 +41,9 @@ public class ClockShield extends
                     frame.addByteArgument((byte) calendar.get(Calendar.SECOND));
                     sendShieldFrame(frame);
                 }
-                String hour = calendar.get(Calendar.HOUR_OF_DAY) + "";
-                String min = calendar.get(Calendar.MINUTE) + "";
-                String sec = calendar.get(Calendar.SECOND) + "";
+                String hour = String.valueOf(calendar.get(Calendar.HOUR_OF_DAY));
+                String min = String.valueOf(calendar.get(Calendar.MINUTE));
+                String sec = String.valueOf(calendar.get(Calendar.SECOND));
                 if (eventHandler != null)
                     eventHandler.onTimeChanged(""
                                     + (hour.length() == 1 ? "0" + hour : hour) + ":"
@@ -78,9 +78,9 @@ public class ClockShield extends
 
             // frame.addByteArgument((byte) year);
             sendShieldFrame(frame);
-            String hour = calendar.get(Calendar.HOUR_OF_DAY) + "";
-            String min = calendar.get(Calendar.MINUTE) + "";
-            String sec = calendar.get(Calendar.SECOND) + "";
+            String hour = String.valueOf(calendar.get(Calendar.HOUR_OF_DAY));
+            String min = String.valueOf(calendar.get(Calendar.MINUTE));
+            String sec = String.valueOf(calendar.get(Calendar.SECOND));
             if (eventHandler != null)
                 eventHandler.onTimeChanged(""
                                 + (hour.length() == 1 ? "0" + hour : hour) + ":"
@@ -127,9 +127,9 @@ public class ClockShield extends
 
                 // frame.addByteArgument((byte) year);
                 sendShieldFrame(frame);
-                String hour = calendar.get(Calendar.HOUR_OF_DAY) + "";
-                String min = calendar.get(Calendar.MINUTE) + "";
-                String sec = calendar.get(Calendar.SECOND) + "";
+                String hour = String.valueOf(calendar.get(Calendar.HOUR_OF_DAY));
+                String min = String.valueOf(calendar.get(Calendar.MINUTE));
+                String sec = String.valueOf(calendar.get(Calendar.SECOND));
                 if (eventHandler != null)
                     eventHandler.onTimeChanged(""
                                     + (hour.length() == 1 ? "0" + hour : hour) + ":"
@@ -281,9 +281,9 @@ public class ClockShield extends
                 }
             }
             setTime();
-            String hour = calendar.get(Calendar.HOUR_OF_DAY) + "";
-            String min = calendar.get(Calendar.MINUTE) + "";
-            String sec = calendar.get(Calendar.SECOND) + "";
+            String hour = String.valueOf(calendar.get(Calendar.HOUR_OF_DAY));
+            String min = String.valueOf(calendar.get(Calendar.MINUTE));
+            String sec = String.valueOf(calendar.get(Calendar.SECOND));
             if (eventHandler != null)
                 eventHandler.onTimeChanged(
                         "" + (hour.length() == 1 ? "0" + hour : hour) + ":"

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/shields/controller/DataLoggerShield.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/shields/controller/DataLoggerShield.java
@@ -192,8 +192,8 @@ public class DataLoggerShield extends ControllerParent<DataLoggerShield> {
                     folder.mkdirs();
                 }
                 fullFileName = (fileName == null
-                        || fileName.length() == 0 ? new Date()
-                        .getTime() + ""
+                        || fileName.length() == 0 ? String.valueOf(new Date()
+                        .getTime())
                         : fileName + " - " + new Date()
                         .getTime()) + ".csv";
                 filePath = Environment

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/shields/fragments/AccelerometerFragment.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/shields/fragments/AccelerometerFragment.java
@@ -87,7 +87,7 @@ public class AccelerometerFragment extends
                 @Override
                 public void run() {
                     if (canChangeUI())
-                        x.setText("" + value[0]);
+                        x.setText(String.valueOf(value[0]));
                 }
             });
             y.post(new Runnable() {
@@ -95,7 +95,7 @@ public class AccelerometerFragment extends
                 @Override
                 public void run() {
                     if (canChangeUI())
-                        y.setText("" + value[1]);
+                        y.setText(String.valueOf(value[1]));
                 }
             });
             z.post(new Runnable() {
@@ -103,7 +103,7 @@ public class AccelerometerFragment extends
                 @Override
                 public void run() {
                     if (canChangeUI())
-                        z.setText("" + value[2]);
+                        z.setText(String.valueOf(value[2]));
 
                 }
             });

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/shields/fragments/GravityFragment.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/shields/fragments/GravityFragment.java
@@ -79,7 +79,7 @@ public class GravityFragment extends ShieldFragmentParent<GravityFragment> {
                 @Override
                 public void run() {
                     if (canChangeUI())
-                        x.setText("" + value[0]);
+                        x.setText(String.valueOf(value[0]));
                 }
             });
             y.post(new Runnable() {
@@ -87,7 +87,7 @@ public class GravityFragment extends ShieldFragmentParent<GravityFragment> {
                 @Override
                 public void run() {
                     if (canChangeUI())
-                        y.setText("" + value[1]);
+                        y.setText(String.valueOf(value[1]));
                 }
             });
             z.post(new Runnable() {
@@ -95,7 +95,7 @@ public class GravityFragment extends ShieldFragmentParent<GravityFragment> {
                 @Override
                 public void run() {
                     if (canChangeUI())
-                        z.setText("" + value[2]);
+                        z.setText(String.valueOf(value[2]));
 
                 }
             });

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/shields/fragments/GyroscopeFragment.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/shields/fragments/GyroscopeFragment.java
@@ -81,7 +81,7 @@ public class GyroscopeFragment extends ShieldFragmentParent<GyroscopeFragment> {
                 @Override
                 public void run() {
                     if (canChangeUI())
-                        x.setText("" + value[0]);
+                        x.setText(String.valueOf(value[0]));
                 }
             });
             y.post(new Runnable() {
@@ -89,7 +89,7 @@ public class GyroscopeFragment extends ShieldFragmentParent<GyroscopeFragment> {
                 @Override
                 public void run() {
                     if (canChangeUI())
-                        y.setText("" + value[1]);
+                        y.setText(String.valueOf(value[1]));
                 }
             });
             z.post(new Runnable() {
@@ -97,7 +97,7 @@ public class GyroscopeFragment extends ShieldFragmentParent<GyroscopeFragment> {
                 @Override
                 public void run() {
                     if (canChangeUI())
-                        z.setText("" + value[2]);
+                        z.setText(String.valueOf(value[2]));
 
                 }
             });

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/shields/fragments/MagnetometerFragment.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/shields/fragments/MagnetometerFragment.java
@@ -83,7 +83,7 @@ public class MagnetometerFragment extends
                 @Override
                 public void run() {
                     if (canChangeUI())
-                        x.setText("" + value[0]);
+                        x.setText(String.valueOf(value[0]));
                 }
             });
             y.post(new Runnable() {
@@ -91,7 +91,7 @@ public class MagnetometerFragment extends
                 @Override
                 public void run() {
                     if (canChangeUI())
-                        y.setText("" + value[1]);
+                        y.setText(String.valueOf(value[1]));
                 }
             });
             z.post(new Runnable() {
@@ -99,7 +99,7 @@ public class MagnetometerFragment extends
                 @Override
                 public void run() {
                     if (canChangeUI())
-                        z.setText("" + value[2]);
+                        z.setText(String.valueOf(value[2]));
 
                 }
             });

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/shields/fragments/OrientationFragment.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/shields/fragments/OrientationFragment.java
@@ -82,7 +82,7 @@ public class OrientationFragment extends
                 @Override
                 public void run() {
                     if (canChangeUI())
-                        x.setText("" + value[0]);
+                        x.setText(String.valueOf(value[0]));
                 }
             });
             y.post(new Runnable() {
@@ -90,7 +90,7 @@ public class OrientationFragment extends
                 @Override
                 public void run() {
                     if (canChangeUI())
-                        y.setText("" + value[1]);
+                        y.setText(String.valueOf(value[1]));
                 }
             });
             z.post(new Runnable() {
@@ -98,7 +98,7 @@ public class OrientationFragment extends
                 @Override
                 public void run() {
                     if (canChangeUI())
-                        z.setText("" + value[2]);
+                        z.setText(String.valueOf(value[2]));
 
                 }
             });


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2131 - “Primitives should not be boxed just for "String" conversion”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
Ayman Abdelghany.
