### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/oneSheeld/src/main/java/com/integreight/firmatabluetooth/ArduinoFirmata.java
+++ b/oneSheeld/src/main/java/com/integreight/firmatabluetooth/ArduinoFirmata.java
@@ -559,9 +559,9 @@ public class ArduinoFirmata {
     private void printFrameToLog(byte[] frame, String tag) {
         String s = "";
         for (byte b : frame) {
-            if ((Integer.toHexString(b).length() < 2))
+            if (Integer.toHexString(b).length() < 2)
                 s += "0" + Integer.toHexString(b) + " ";
-            else if ((Integer.toHexString(b).length() == 2))
+            else if (Integer.toHexString(b).length() == 2)
                 s += Integer.toHexString(b) + " ";
             else {
                 String temp = Integer.toHexString(b);
@@ -858,7 +858,7 @@ public class ArduinoFirmata {
             // TODO Auto-generated method stub
             while (!this.isInterrupted()) {
                 try {
-                    while ((readByteFromUartBuffer()) != ShieldFrame.START_OF_FRAME)
+                    while (readByteFromUartBuffer() != ShieldFrame.START_OF_FRAME)
                         ;
                     if (ShieldFrameTimeout != null)
                         ShieldFrameTimeout.stopTimer();
@@ -905,7 +905,7 @@ public class ArduinoFirmata {
                         frame.addArgument(data);
                     }
                     if (continueRequested) continue;
-                    if ((readByteFromUartBuffer()) != ShieldFrame.END_OF_FRAME) {
+                    if (readByteFromUartBuffer() != ShieldFrame.END_OF_FRAME) {
                         if (ShieldFrameTimeout != null)
                             ShieldFrameTimeout.stopTimer();
                         uartBuffer.clear();

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/plugin/action/ActionActivity.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/plugin/action/ActionActivity.java
@@ -91,7 +91,7 @@ public final class ActionActivity extends AbstractPluginActivity {
     @Override
     public void finish() {
         if (!isCanceled()) {
-            final boolean output = (outputSpinner).getSelectedItem().toString()
+            final boolean output = outputSpinner.getSelectedItem().toString()
                     .toLowerCase().equals("high") ? true : false;
             final Intent resultIntent = new Intent();
             final Bundle resultBundle = PluginBundleManager

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/plugin/condition/ConditionActivity.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/plugin/condition/ConditionActivity.java
@@ -89,7 +89,7 @@ public final class ConditionActivity extends AbstractPluginActivity {
     @Override
     public void finish() {
         if (!isCanceled()) {
-            final boolean output = (outputSpinner).getSelectedItem().toString()
+            final boolean output = outputSpinner.getSelectedItem().toString()
                     .toLowerCase().equals("high") ? true : false;
             final Intent resultIntent = new Intent();
             final Bundle resultBundle = PluginBundleManager

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/shields/controller/SkypeShield.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/shields/controller/SkypeShield.java
@@ -183,9 +183,9 @@ public class SkypeShield extends ControllerParent<SkypeShield> {
             myPackageMgr.getPackageInfo("com.skype.raider",
                     PackageManager.GET_ACTIVITIES);
         } catch (PackageManager.NameNotFoundException e) {
-            return (false);
+            return false;
         }
-        return (true);
+        return true;
     }
 
     @Override

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/shields/controller/TerminalShield.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/shields/controller/TerminalShield.java
@@ -181,9 +181,9 @@ public class TerminalShield extends ControllerParent<TerminalShield> {
             case 3:
                 byte[] byts = toBeEncoded.getBytes();
                 for (byte b : byts) {
-                    if ((Integer.toHexString(b).length() < 2))
+                    if (Integer.toHexString(b).length() < 2)
                         out += "0" + Integer.toHexString(b) + " ";
-                    else if ((Integer.toHexString(b).length() == 2))
+                    else if (Integer.toHexString(b).length() == 2)
                         out += Integer.toHexString(b) + " ";
                     else {
                         String temp = Integer.toHexString(b);

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/shields/fragments/CameraFragment.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/shields/fragments/CameraFragment.java
@@ -261,7 +261,7 @@ public class CameraFragment extends ShieldFragmentParent<CameraFragment> impleme
                 } else {
                     if ((CameraShield) getApplication().getRunningShields().get(getControllerTag()) != null)
                         try {
-                            if ((((CameraShield) getApplication().getRunningShields().get(getControllerTag())).hidePreview()))
+                            if (((CameraShield) getApplication().getRunningShields().get(getControllerTag())).hidePreview())
                                 camerLogo.setVisibility(View.VISIBLE);
 //                        else
 //                            cameraPreviewToggle.setChecked(true);

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/shields/fragments/FacebookFragment.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/shields/fragments/FacebookFragment.java
@@ -171,7 +171,7 @@ public class FacebookFragment extends ShieldFragmentParent<FacebookFragment> imp
     };
 
     private void initializeFirmata() {
-        if ((getApplication().getRunningShields().get(getControllerTag())) == null)
+        if (getApplication().getRunningShields().get(getControllerTag()) == null)
             getApplication().getRunningShields().put(
                     getControllerTag(),
                     new FacebookShield(activity, getControllerTag(), this,
@@ -185,7 +185,7 @@ public class FacebookFragment extends ShieldFragmentParent<FacebookFragment> imp
     }
 
     private void checkLogin() {
-        if ((getApplication().getRunningShields().get(getControllerTag())) != null
+        if (getApplication().getRunningShields().get(getControllerTag()) != null
                 && ((FacebookShield) getApplication().getRunningShields().get(
                 getControllerTag())).isFacebookLoggedInAlready()) {
             buttonToLoggedIn();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.
