### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/localeapi/src/main/java/com/twofortyfouram/locale/PackageUtilities.java
+++ b/localeapi/src/main/java/com/twofortyfouram/locale/PackageUtilities.java
@@ -45,6 +45,9 @@ public final class PackageUtilities
      */
     private static final Set<String> COMPATIBLE_PACKAGES = constructPackageSet();
 
+    private PackageUtilities() {
+    }
+
     /**
      * @return a list wrapped in {@link Collections#unmodifiableList(List)} that represents the set of
      *         Locale-compatible packages.

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/plugin/BundleScrubber.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/plugin/BundleScrubber.java
@@ -16,6 +16,9 @@ import android.content.Intent;
 import android.os.Bundle;
 
 public final class BundleScrubber {
+    private BundleScrubber() {
+    }
+
     public static boolean scrub(final Intent intent) {
         if (null == intent) {
             return false;

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/shields/controller/utils/CameraUtils.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/shields/controller/utils/CameraUtils.java
@@ -23,6 +23,9 @@ public class CameraUtils {
     private static SharedPreferences.Editor editor;
     private static final String sharedPreferencesKey = "LastImage";
 
+    private CameraUtils() {
+    }
+
     public static Camera.Size getBiggestPictureSize(
             Camera.Parameters parameters) {
         Camera.Size result = null;

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/shields/controller/utils/FoursquareUtils.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/shields/controller/utils/FoursquareUtils.java
@@ -24,6 +24,9 @@ import java.net.URLEncoder;
 
 public final class FoursquareUtils {
 
+    private FoursquareUtils() {
+    }
+
     public static String encodePostBody(Bundle parameters, String boundary) {
         if (parameters == null)
             return "";

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/shields/controller/utils/ImageUtils.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/shields/controller/utils/ImageUtils.java
@@ -19,6 +19,9 @@ import java.util.List;
 import java.util.Map;
 
 public class ImageUtils {
+    private ImageUtils() {
+    }
+
     public static Bitmap decodeFile(File f, int required_size) {
         try {
             // Decode image size

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/shields/controller/utils/SensorUtil.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/shields/controller/utils/SensorUtil.java
@@ -7,6 +7,9 @@ public class SensorUtil {
     public static PackageManager PM;
     public static boolean sensor;
 
+    private SensorUtil() {
+    }
+
     public static Boolean isDeviceHasSensor(String sensorType, Context mContext) {
 
         PM = mContext.getPackageManager();

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/utils/ArrayUtils.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/utils/ArrayUtils.java
@@ -1,6 +1,9 @@
 package com.integreight.onesheeld.utils;
 
 public class ArrayUtils {
+    private ArrayUtils() {
+    }
+
     public static byte[] copyOfRange(byte[] from, int start, int end) {
         int length = end - start;
         byte[] result = new byte[length];

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/utils/BitsUtils.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/utils/BitsUtils.java
@@ -2,6 +2,9 @@ package com.integreight.onesheeld.utils;
 
 public class BitsUtils {
 
+    private BitsUtils() {
+    }
+
     public static byte setBit(byte b, int bit) {
         if (bit < 0 || bit >= 8) return b;
         return (byte) (b | (1 << bit));

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/utils/CrashlyticsUtils.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/utils/CrashlyticsUtils.java
@@ -1,6 +1,9 @@
 package com.integreight.onesheeld.utils;
 
 public class CrashlyticsUtils {
+    private CrashlyticsUtils() {
+    }
+
     public static void setString(String key, String value) {
         try {
             com.crashlytics.android.Crashlytics.setString(key, value);

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/utils/customviews/PinsColumnContainer.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/utils/customviews/PinsColumnContainer.java
@@ -240,6 +240,9 @@ public class PinsColumnContainer extends RelativeLayout {
             public final static int NOT_CONNECTED_AND_ENABLED = R.drawable.arduino_default_pin;
             public final static int DISABLED = R.drawable.arduino_red_pin;
             public final static int DUMMY = R.drawable.arduino_dummy_pin;
+
+            private TYPE() {
+            }
         }
 
     }

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/utils/customviews/PluginPinsColumnContainer.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/utils/customviews/PluginPinsColumnContainer.java
@@ -226,6 +226,9 @@ public class PluginPinsColumnContainer extends RelativeLayout {
             public final static int NOT_CONNECTED_AND_ENABLED = R.drawable.arduino_default_pin;
             public final static int DISABLED = R.drawable.arduino_red_pin;
             public final static int DUMMY = R.drawable.arduino_dummy_pin;
+
+            private TYPE() {
+            }
         }
 
     }

--- a/oneSheeld/src/main/java/com/integreight/onesheeld/utils/customviews/utils/LockPatternUtils.java
+++ b/oneSheeld/src/main/java/com/integreight/onesheeld/utils/customviews/utils/LockPatternUtils.java
@@ -25,6 +25,9 @@ import java.util.List;
  */
 public class LockPatternUtils {
 
+    private LockPatternUtils() {
+    }
+
     /**
      * Deserialize a pattern.
      *

--- a/pullToRefreshlibrary/src/main/java/com/handmark/pulltorefresh/library/AlphaAnimator.java
+++ b/pullToRefreshlibrary/src/main/java/com/handmark/pulltorefresh/library/AlphaAnimator.java
@@ -25,7 +25,10 @@ import android.view.animation.Animation.AnimationListener;
  *
  */
 class AlphaAnimator {
-	
+
+	private AlphaAnimator() {
+	}
+
 	public static void fadein(View view, int duration) {
 		fadein(view, duration, null);
 	}

--- a/pullToRefreshlibrary/src/main/java/com/handmark/pulltorefresh/library/OverscrollHelper.java
+++ b/pullToRefreshlibrary/src/main/java/com/handmark/pulltorefresh/library/OverscrollHelper.java
@@ -29,6 +29,9 @@ public final class OverscrollHelper {
 	static final String LOG_TAG = "OverscrollHelper";
 	static final float DEFAULT_OVERSCROLL_SCALE = 1f;
 
+	private OverscrollHelper() {
+	}
+
 	/**
 	 * Helper method for Overscrolling that encapsulates all of the necessary
 	 * function.

--- a/pullToRefreshlibrary/src/main/java/com/handmark/pulltorefresh/library/internal/Utils.java
+++ b/pullToRefreshlibrary/src/main/java/com/handmark/pulltorefresh/library/internal/Utils.java
@@ -36,6 +36,10 @@ public class Utils {
 	 *  Invalid android attribute (temporarily defined, to check android attributes' values)
 	 */
 	static final int INVALID_INT_VALUE = -1;
+
+	private Utils() {
+	}
+
 	/**
 	 * Delegate warn logs at where some deprecated method has been called
 	 * @param depreacted Deprecated method name


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
